### PR TITLE
Fix for empty names and empty times

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,8 +107,8 @@ export function Normalize(p: Pack): Pack | Error {
     if (r.bs && r.bs !== 0) bsum = r.bs;
     if (r.bu && r.bu !== '') bunit = r.bu;
     if (r.bn && r.bn.length > 0) bname = r.bn;
-    if (r.t && btime) r.t = r.t + btime;
-
+    
+    r.t = (r.t ?? 0) + btime;
     r.n = bname + (r.n ?? '');
 
     if (r.s && bsum) r.s = bsum + r.s;

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ export function Normalize(p: Pack): Pack | Error {
     if (r.bn && r.bn.length > 0) bname = r.bn;
     if (r.t && btime) r.t = r.t + btime;
 
-    r.n = bname + r.n;
+    r.n = bname + (r.n ?? '');
 
     if (r.s && bsum) r.s = bsum + r.s;
     if ((!r.u || r.u === '') && bunit) r.u = bunit;

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,8 +108,8 @@ export function Normalize(p: Pack): Pack | Error {
     if (r.bu && r.bu !== '') bunit = r.bu;
     if (r.bn && r.bn.length > 0) bname = r.bn;
     
-    r.t = (r.t ?? 0) + btime;
-    r.n = bname + (r.n ?? '');
+    r.t = (r.t !== undefined && r.t !== null ? r.t : 0) + btime;
+    r.n = bname + (r.n !== undefined && r.n !== null ? r.n : '');
 
     if (r.s && bsum) r.s = bsum + r.s;
     if ((!r.u || r.u === '') && bunit) r.u = bunit;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,7 @@ import {
   Validate,
   Normalize,
   Format,
+  Record,
   ErrEmptyName,
   ErrBadChar,
   ErrNoValues,
@@ -197,4 +198,66 @@ describe('Normalize SenML record', () => {
   it('should be able to normalize senML record with error', () => {
     expect(Normalize(emptyName)).to.equal(ErrEmptyName);
   });
+});
+
+describe('rfc8428', () => {
+  // TODO: should we maybe include the whole example 5.1.3 from rfc8428 here?
+  it('normalizes example 5.1.3 correctly', () => {
+    const input =
+      [
+        {
+          "bn": "urn:dev:ow:10e2073a01080063",
+          "bt": 1.320067464e+09,
+          "bu": "%RH",
+          "v": 20,
+        },
+        {
+          "u": "lon",
+          "v": 24.30621
+        },
+        {
+          "t": 60,
+          "v": 20.3
+        },
+      ];
+
+    const expected: Record[] =
+      [
+        {
+          "bn": "",
+          "bs": 0,
+          "bt": 0,
+          "bu": "",
+          "bv": 0,
+          "n": "urn:dev:ow:10e2073a01080063",
+          "u": "%RH",
+          "t": 1.320067464e+09,
+          "v": 20
+        },
+        {
+          "bn": "",
+          "bs": 0,
+          "bt": 0,
+          "bu": "",
+          "bv": 0,
+          "n": "urn:dev:ow:10e2073a01080063",
+          "u": "lon",
+          "t": 1.320067464e+09,
+          "v": 24.30621
+        },
+        {
+          "bn": "",
+          "bs": 0,
+          "bt": 0,
+          "bu": "",
+          "bv": 0,
+          "n": "urn:dev:ow:10e2073a01080063",
+          "u": "%RH",
+          "t": 1.320067524e+09,
+          "v": 20.3
+        },
+      ];
+
+    expect(Normalize({ Records: input })).to.deep.equal({ Records: expected });
+  })
 });


### PR DESCRIPTION
Hi @marcotuna,

first of all thanks for your work and this great package!

I've tried to normalize an example from the RFC8428, namely [example 5.1.3](https://datatracker.ietf.org/doc/html/rfc8428#section-5.1.3) and have come across the issue that the library did not handle empty names and empty timestamps well, when there is only a base name and a base time given.

This PR should fix both issues. I've also included a test for this very example.
I was just thinking whether it makes sense to include the whole example 5.1.3 into the test-case. What is your opinion on this?

Best regards,
Gabriel