### PR TITLE
ci(test): add node 18 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     
     strategy:
       matrix:
-        node: [ '12', '14', '16' ]
+        node: [ '12', '14', '16', '18' ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This pull request adds support for NodeJS 18 in our Github Action workflow. With this change, we can ensure that our tests are also passing on the latest version of NodeJS.

To achieve this, we updated the workflow file to include the new NodeJS 18 version.

By adding support for NodeJS 18, we can ensure that our codebase is compatible with the latest version of NodeJS and that we can take advantage of any new features and optimizations available in this version. This will help us to maintain the quality and reliability of our software and stay up-to-date with the latest technologies.
