### PR TITLE
Fix for nullish values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,8 +107,8 @@ export function Normalize(p: Pack): Pack | Error {
     if (r.bs && r.bs !== 0) bsum = r.bs;
     if (r.bu && r.bu !== '') bunit = r.bu;
     if (r.bn && r.bn.length > 0) bname = r.bn;
-    if (r.t && btime) r.t = r.t + btime;
-
+    
+    r.t = (r.t ?? 0) + btime;
     r.n = bname + (r.n ?? '');
 
     if (r.s && bsum) r.s = bsum + r.s;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { isNullish } from "./utils";
+
 export const ErrVersionChange = { name: 'ErrVersionChange', message: 'version change' };
 export const ErrUnsuportedFormat = { name: 'ErrUnsupportedFormat', message: 'unsupported format' };
 export const ErrEmptyName = { name: 'ErrEmptyName', message: 'empty name' };
@@ -162,10 +164,10 @@ export function Validate(p: Pack): Error | null {
     if (name.length === 0) return ErrEmptyName;
 
     let valCnt = 0;
-    if (r.v) valCnt++;
-    if (r.vb) valCnt++;
-    if (r.vd) valCnt++;
-    if (r.vs) valCnt++;
+    if (!isNullish(r.v)) valCnt++;
+    if (!isNullish(r.vb)) valCnt++;
+    if (!isNullish(r.vd)) valCnt++;
+    if (!isNullish(r.vs)) valCnt++;
 
     if (valCnt > 1) return ErrTooManyValues;
     if (r.s || bsum !== 0) valCnt++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ export function Normalize(p: Pack): Pack | Error {
     if (r.bn && r.bn.length > 0) bname = r.bn;
     if (r.t && btime) r.t = r.t + btime;
 
-    r.n = bname + r.n;
+    r.n = bname + (r.n ?? '');
 
     if (r.s && bsum) r.s = bsum + r.s;
     if ((!r.u || r.u === '') && bunit) r.u = bunit;

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,8 +108,8 @@ export function Normalize(p: Pack): Pack | Error {
     if (r.bu && r.bu !== '') bunit = r.bu;
     if (r.bn && r.bn.length > 0) bname = r.bn;
     
-    r.t = (r.t ?? 0) + btime;
-    r.n = bname + (r.n ?? '');
+    r.t = (r.t !== undefined && r.t !== null ? r.t : 0) + btime;
+    r.n = bname + (r.n !== undefined && r.n !== null ? r.n : '');
 
     if (r.s && bsum) r.s = bsum + r.s;
     if ((!r.u || r.u === '') && bunit) r.u = bunit;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,7 @@ export function fromHex(h: string): string {
     }
     return decodeURIComponent(escape(s))
 }
+
+export function isNullish(h: string | number | boolean | null | undefined): boolean {
+    return h === null || h === undefined;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -198,6 +198,85 @@ describe('Normalize SenML record', () => {
   it('should be able to normalize senML record with error', () => {
     expect(Normalize(emptyName)).to.equal(ErrEmptyName);
   });
+
+  it('should be able to handle nullish values', () => {
+    // vb has value "false", which should be identified as a valid value
+    const input: Record[] =
+      [
+        {
+          bn: "urn:dev:mac:d6ea13fffff5113b:",
+          bt: 1677102089.0,
+          n: "batt",
+          u: "%EL",
+          v: 0,
+        },
+        {
+          n: "n1",
+          u: "unit",
+          vb: false,
+        },
+        {
+          n: "n2",
+          u: "unit",
+          vd: '',
+        },
+        {
+          n: "n3",
+          u: "unit",
+          vs: '',
+        }
+      ];
+
+    const expected: Record[] =
+      [
+        {
+          bn: '',
+          bt: 0,
+          n: 'urn:dev:mac:d6ea13fffff5113b:batt',
+          u: '%EL',
+          v: 0,
+          t: 1677102089,
+          bv: 0,
+          bu: '',
+          bs: 0
+        },
+        {
+          n: 'urn:dev:mac:d6ea13fffff5113b:n1',
+          vb: false,
+          t: 1677102089,
+          u: 'unit',
+          bt: 0,
+          bv: 0,
+          bu: '',
+          bn: '',
+          bs: 0
+        },
+        {
+          n: 'urn:dev:mac:d6ea13fffff5113b:n2',
+          t: 1677102089,
+          u: 'unit',
+          vd: '',
+          bt: 0,
+          bv: 0,
+          bu: '',
+          bn: '',
+          bs: 0
+        },
+        {
+          n: 'urn:dev:mac:d6ea13fffff5113b:n3',
+          t: 1677102089,
+          u: 'unit',
+          vs: '',
+          bt: 0,
+          bv: 0,
+          bu: '',
+          bn: '',
+          bs: 0
+        }
+      ];
+
+    expect(Normalize({ Records: input })).to.deep.equal({ Records: expected });
+  });
 });
 
 describe('rfc8428', () => {
@@ -259,5 +338,5 @@ describe('rfc8428', () => {
       ];
 
     expect(Normalize({ Records: input })).to.deep.equal({ Records: expected });
-  })
+  });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,7 @@ import {
   Validate,
   Normalize,
   Format,
+  Record,
   ErrEmptyName,
   ErrBadChar,
   ErrNoValues,
@@ -197,4 +198,66 @@ describe('Normalize SenML record', () => {
   it('should be able to normalize senML record with error', () => {
     expect(Normalize(emptyName)).to.equal(ErrEmptyName);
   });
+});
+
+describe('rfc8428', () => {
+  // TODO: should we maybe include the whole example 5.1.3 from rfc8428 here?
+  it('normalizes example 5.1.3 correctly', () => {
+    const input =
+      [
+        {
+          "bn": "urn:dev:ow:10e2073a01080063",
+          "bt": 1.320067464e+09,
+          "bu": "%RH",
+          "v": 20,
+        },
+        {
+          "u": "lon",
+          "v": 24.30621
+        },
+        {
+          "t": 60,
+          "v": 20.3
+        },
+      ];
+
+    const expected: Record[] =
+      [
+        {
+          "bn": "",
+          "bs": 0,
+          "bt": 0,
+          "bu": "",
+          "bv": 0,
+          "n": "urn:dev:ow:10e2073a01080063",
+          "u": "%RH",
+          "t": 1.320067464e+09,
+          "v": 20
+        },
+        {
+          "bn": "",
+          "bs": 0,
+          "bt": 0,
+          "bu": "",
+          "bv": 0,
+          "n": "urn:dev:ow:10e2073a01080063",
+          "u": "lon",
+          "t": 1.320067464e+09,
+          "v": 24.30621
+        },
+        {
+          "bn": "",
+          "bs": 0,
+          "bt": 0,
+          "bu": "",
+          "bv": 0,
+          "n": "urn:dev:ow:10e2073a01080063",
+          "u": "%RH",
+          "t": 1.320067524e+09,
+          "v": 20.3
+        },
+      ];
+
+    expect(Normalize({ Records: input })).to.deep.equal({ Records: expected });
+  })
 });


### PR DESCRIPTION
Hello @marcotuna, I came across the issue that values that can be interpreted as null/undefined in JavaScript (like `false`, `''` or `0`) were not handled correctly. Therefore I introduced a nullish-check instead of the previous check for `if(r.v)`.

Let me know whether the implementation should be changed/updated in any way.

Best regards,
Gabriel